### PR TITLE
Allow 'setimg' command to match partial filenames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ scsitb setimg <device> <filename>
 
 This requests that a different disk image is mounted on the emulated device.
 Either use the image index given by the `lsimg` command, or specify a filename
-directly.
+directly. Partial names will be matched based on the first item encountered that
+starts with the given filename.
 
 ```
 C:\> scsitb setimg 1 ezscsi4.iso

--- a/dos/tbdos.cpp
+++ b/dos/tbdos.cpp
@@ -165,7 +165,7 @@ static int FindFilenameInList(const WCValOrderedVector<ToolboxFileEntry> &files,
 {
     for (int i = 0; i < files.entries(); i++) {
         const ToolboxFileEntry &tfe = files[i];
-        if (strncasecmp(tfe.name, searchname, sizeof(tfe.name) - 1) == 0) {
+        if (strncasecmp(tfe.name, searchname, strlen(searchname)) == 0) {
             printf("Selected file %d: %s\n", tfe.index, tfe.name);
             return tfe.index;
         }

--- a/dos/tbdos.cpp
+++ b/dos/tbdos.cpp
@@ -605,7 +605,7 @@ static void PrintHelp(void)
         "  debug <dev> [flag]      Show or set device firmware debug flag.\n"
         "  lsimg <dev>             List available images for the given device.\n"
         "  setimg <dev> <img>      Change the mounted image in the given device, to\n"
-        "                          the image with the given index or filename.\n"
+        "                          the image with the given index or partial filename.\n"
         "  lsdir <dev>             List shared directory for the given decice.\n"
         "  get <dev> <file> [name] Download a file from the shared directory.\n"
         "  put <dev> <filename>    Upload a file to the shared directory.\n"


### PR DESCRIPTION
Being able to specify a filename for `setimg` is great but it would be nice to not have to type out longer names, or remember which items are .iso/.bin/etc. PR is just a trivial logic change to let comparisons match based on user inputs that are shorter than the full filename.